### PR TITLE
feat: log error when all connections have been used

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
@@ -55,7 +55,10 @@ class DatabaseConnectionPool(object):
 
     def get(self):
         try:
-            if self.size >= self.maxsize or self.pool.qsize():
+            size = self.size 
+            if size >= self.maxsize:
+                logger.error('%s out of %s database connections used', size, self.maxsize)
+            if size >= self.maxsize or self.pool.qsize():
                 conn = self.pool.get()
             else:
                 conn = self.pool.get_nowait()


### PR DESCRIPTION
For many purposes this is an error condition - using all allocated database connections means that client code is waiting, and action should be taken.