### PR TITLE
refactor: removing eventlet and python 2 code

### DIFF
--- a/django_db_geventpool/utils.py
+++ b/django_db_geventpool/utils.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 from functools import wraps
-from contextlib import contextmanager
 
 from django.core.signals import request_finished
 
@@ -14,8 +13,3 @@ def close_connection(f):
         finally:
             request_finished.send(sender='greenlet')
     return wrapper
-
-
-@contextmanager
-def nullcontext(enter_result=None):
-    yield enter_result


### PR DESCRIPTION
-eventlet was only used as a fallback for gevent
-python 2 code somewhat redundant